### PR TITLE
Remove OSXDashboardPlayer check, removed in 2017.2

### DIFF
--- a/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
+++ b/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
@@ -323,8 +323,7 @@ namespace GracesGames {
 		// Returns whether the application is run on a Mac Operating System
 		private bool IsMacOsPlatform() {
 			return (Application.platform == RuntimePlatform.OSXEditor ||
-			        Application.platform == RuntimePlatform.OSXPlayer ||
-			        Application.platform == RuntimePlatform.OSXDashboardPlayer);
+			        Application.platform == RuntimePlatform.OSXPlayer);
 		}
 		
 		// Creates a directory button given a directory


### PR DESCRIPTION
Closes #5

Since it will never be released for the OSXDashboardPlayer, I will remove this check in the code. 
This will make it compile for version >= 2017.2