### PR TITLE
Android navigation related bug fixes

### DIFF
--- a/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
+++ b/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
@@ -110,17 +110,8 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 		// String file extension to filter results and save new files
 		private string _fileExtension;
 
-		// ----- METHODS -----
-		public void Awake() {
-			if(IsAndroidPlatform()) {
-			 AndroidJavaClass jc = new AndroidJavaClass("android.os.Environment") ;
-             _rootAndroidPath  = jc.CallStatic<AndroidJavaObject>("getExternalStorageDirectory").Call<string>("getAbsolutePath");
-			 _currentPath = _rootAndroidPath;
-			} else {
-				_currentPath = Directory.GetCurrentDirectory();
-			}
-		}
-
+		// ----- METHODS ----//
+		
 		// Finds and returns a game object by name or prints an error and return null
 		private GameObject FindGameObjectOrError(string objectName) {
 			GameObject foundGameObject = GameObject.Find(objectName);

--- a/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
+++ b/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
@@ -111,7 +111,6 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 		private string _fileExtension;
 
 		// ----- METHODS -----
-
 		public void Awake() {
 			if(isAndroidPlatform()) {
 			 AndroidJavaClass jc = new AndroidJavaClass("android.os.Environment") ;

--- a/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
+++ b/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
@@ -112,7 +112,7 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 
 		// ----- METHODS -----
 		public void Awake() {
-			if(isAndroidPlatform()) {
+			if(IsAndroidPlatform()) {
 			 AndroidJavaClass jc = new AndroidJavaClass("android.os.Environment") ;
              _rootAndroidPath  = jc.CallStatic<AndroidJavaObject>("getExternalStorageDirectory").Call<string>("getAbsolutePath");
 			 _currentPath = _rootAndroidPath;
@@ -201,6 +201,18 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 			// and hook up onValueChanged listener to update search results on value change
 			_searchInputField = FindGameObjectOrError("SearchInputField").GetComponent<InputField>();
 			_searchInputField.onValueChanged.AddListener(UpdateSearchFilter);
+			
+			if (IsAndroidPlatform()) {
+				SetupAndroidVariables();
+				_currentPath = _rootAndroidPath ;
+			} else {
+				_currentPath = Directory.GetCurrentDirectory();
+			}
+		}
+
+		private void SetupAndroidVariables() {
+			 AndroidJavaClass jc = new AndroidJavaClass("android.os.Environment") ;
+             _rootAndroidPath  = jc.CallStatic<AndroidJavaObject>("getExternalStorageDirectory").Call<string>("getAbsolutePath");
 		}
 		
 		// Returns to the previously selected directory (inverse of DirectoryForward)
@@ -239,7 +251,7 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 		// When there is no parent, show the drives of the computer
 		private void DirectoryUp() {
 			_backwardStack.Push(_currentPath);
-			if (!isTopLevelreached()) {
+			if (!IsTopLevelreached()) {
 				_currentPath = Directory.GetParent(_currentPath).FullName;
 				UpdateFileBrowser();
 			} else {
@@ -247,9 +259,9 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 			}
 		}
 
-		// parent direcotry check as android throws permisison error of tried to go above root external storage directory
-		private bool isTopLevelreached() {
-			if(Application.platform == RuntimePlatform.Android) {
+		// parent directory check as android throws permisison error of tried to go above root external storage directory
+		private bool IsTopLevelreached() {
+			if(IsAndroidPlatform()) {
 				return Directory.GetParent(_currentPath).FullName == Directory.GetParent(_rootAndroidPath).FullName;
 			} else {
 				return Directory.GetParent(_currentPath) == null;
@@ -346,7 +358,7 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 					directories = Directory.GetLogicalDrives();
 				} else if (IsMacOsPlatform()) {
 					directories = Directory.GetDirectories("/Volumes");
-				} else if (isAndroidPlatform()) {
+				} else if (IsAndroidPlatform()) {
 					_currentPath = _rootAndroidPath;
 					directories = Directory.GetDirectories(_currentPath);
 				}
@@ -366,7 +378,7 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 			        Application.platform == RuntimePlatform.WindowsPlayer);
 		}
 
-		private bool isAndroidPlatform () {
+		private bool IsAndroidPlatform () {
 			return Application.platform == RuntimePlatform.Android;
 		}
 

--- a/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
+++ b/Assets/SimpleFileBrowser/Scripts/GracesGames/FileBrowser.cs
@@ -116,7 +116,6 @@ namespace SimpleFileBrowser.Scripts.GracesGames {
 			 AndroidJavaClass jc = new AndroidJavaClass("android.os.Environment") ;
              _rootAndroidPath  = jc.CallStatic<AndroidJavaObject>("getExternalStorageDirectory").Call<string>("getAbsolutePath");
 			 _currentPath = _rootAndroidPath;
-			 Debug.Log(Directory.GetParent(_rootAndroidPath).ToString());
 			} else {
 				_currentPath = Directory.GetCurrentDirectory();
 			}


### PR DESCRIPTION
The pull request tries to address the following issues i faced while using the asset on android device.

-  issue - the `Directory.GetCurrentDirectory()` returns the apps internal storage directory for android which is usually inaccessible on unrooted android devices and hence gives an access denied error on `Directory.GetDirectories()`. 
- fix - changed the default `_currentPath` to the location of external storage directory on the device for android

-  issue - Navigation breaks dues to access denied on unrooted devices when the `DirectoryUp()` method tries to go above the android external storage directory as the check `Directory.GetParent(_currentPath) != null` would return true at that level.
- fix - added an additional for android platform checking for the above solution