### PR TITLE
Update FileBrowser.cs

### DIFF
--- a/Assets/GracesGames/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Assets/GracesGames/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -271,7 +271,9 @@ namespace GracesGames.SimpleFileBrowser.Scripts {
 			}
 			// For each directory in the current directory, create a DirectoryButton and hook up the DirectoryClick method
 			foreach (string dir in directories) {
-				_uiScript.CreateDirectoryButton(dir);
+				if (Directory.Exists(dir)){
+					_uiScript.CreateDirectoryButton(dir);
+				}
 			}
 		}
 


### PR DESCRIPTION
Fixes a bug where directories for disk drives are created.  The directory buttons when clicked on cause an error and softlocks the program.