### PR TITLE
Add option to allow multiple file extensions and fix incompatible file hiding bug

### DIFF
--- a/Assets/GracesGames/SimpleFileBrowser/Prefabs/CallerObject.prefab
+++ b/Assets/GracesGames/SimpleFileBrowser/Prefabs/CallerObject.prefab
@@ -53,4 +53,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   FileBrowserPrefab: {fileID: 1760643962491650, guid: 4599b5ba3543545db92bb18160cea721,
     type: 2}
-  FileExtension: txt
+  FileExtensions:
+  - txt
+  PortraitMode: 0

--- a/Assets/GracesGames/SimpleFileBrowser/Scenes/DemoScene.unity
+++ b/Assets/GracesGames/SimpleFileBrowser/Scenes/DemoScene.unity
@@ -115,6 +115,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 114565750721570278, guid: 16a4bdc1909fe4028a30197a43320934,
+        type: 2}
+      propertyPath: FileExtensions.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4455502657589730, guid: 16a4bdc1909fe4028a30197a43320934, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -155,6 +160,16 @@ Prefab:
         type: 2}
       propertyPath: PortraitMode
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 114565750721570278, guid: 16a4bdc1909fe4028a30197a43320934,
+        type: 2}
+      propertyPath: FileExtensions.Array.data[0]
+      value: txt
+      objectReference: {fileID: 0}
+    - target: {fileID: 114565750721570278, guid: 16a4bdc1909fe4028a30197a43320934,
+        type: 2}
+      propertyPath: FileExtensions.Array.data[1]
+      value: meta
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 16a4bdc1909fe4028a30197a43320934, type: 2}

--- a/Assets/GracesGames/SimpleFileBrowser/Scripts/DemoCaller.cs
+++ b/Assets/GracesGames/SimpleFileBrowser/Scripts/DemoCaller.cs
@@ -15,7 +15,7 @@ namespace GracesGames.SimpleFileBrowser.Scripts {
 		public GameObject FileBrowserPrefab;
 
 		// Define a file extension
-		public string FileExtension;
+		public string[] FileExtensions;
 
 		// Input field to get text to save
 		private GameObject _textToSaveInputField;
@@ -60,11 +60,11 @@ namespace GracesGames.SimpleFileBrowser.Scripts {
 			FileBrowser fileBrowserScript = fileBrowserObject.GetComponent<FileBrowser>();
 			fileBrowserScript.SetupFileBrowser(PortraitMode ? ViewMode.Portrait : ViewMode.Landscape);
 			if (fileBrowserMode == FileBrowserMode.Save) {
-				fileBrowserScript.SaveFilePanel("DemoText", FileExtension);
+				fileBrowserScript.SaveFilePanel("DemoText", FileExtensions);
 				// Subscribe to OnFileSelect event (call SaveFileUsingPath using path) 
 				fileBrowserScript.OnFileSelect += SaveFileUsingPath;
 			} else {
-				fileBrowserScript.OpenFilePanel(FileExtension);
+				fileBrowserScript.OpenFilePanel(FileExtensions);
 				// Subscribe to OnFileSelect event (call LoadFileUsingPath using path) 
 				fileBrowserScript.OnFileSelect += LoadFileUsingPath;
 			}

--- a/Assets/GracesGames/SimpleFileBrowser/Scripts/FileBrowser.cs
+++ b/Assets/GracesGames/SimpleFileBrowser/Scripts/FileBrowser.cs
@@ -324,7 +324,7 @@ namespace GracesGames.SimpleFileBrowser.Scripts {
 			foreach (string file in files) {
 				if (!File.Exists(file)) return;
 				// Hide files (no button) with incompatible file extensions when enabled
-				if (HideIncompatibleFiles)
+				if (!HideIncompatibleFiles)
 					_uiScript.CreateFileButton(file);
 				else {
 					if (CompatibleFileExtension(file)) {


### PR DESCRIPTION
#### Check the following before opening the Pull Request:

Description:

Allow multiple file extensions for filtering incompatible files.
Fix bug where hiding incompatible files was not working.

- [x] The code documentation is updated
- [x] Added label (Work in Progress or Ready for Review)
- [x] Assigned yourself
